### PR TITLE
Adds src to files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "types": "dist/index.d.ts"
 }


### PR DESCRIPTION
Resolves the following sourcemap error when using imported package on external app:

```
WARNING in ./node_modules/@REDACTED_SCOPE/REDACTED_REPO/dist/esm/index.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Users/REDACTED_USER/Documents/Projects/my-app/node_modules/@REDACED_SCOPE/REDACTED_REPO/src/components/Autocomplete/Autocomplete.tsx' file: Error: ENOENT: no such file or directory, open '/Users/REDACTED_USER/Documents/Projects/my-app/node_modules/@REDACTED_SCOPE/REDACTED_REPO/src/components/Autocomplete/Autocomplete.tsx'

WARNING in ./node_modules/@REDACTED_SCOPE/REDACTED_REPO/dist/esm/index.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Users/REDACTED_USER/Documents/Projects/my-app/node_modules/@REDACTED_SCOPE/REDACTED_REPO/src/components/Button/Button.tsx' file: Error: ENOENT: no such file or directory, open '/Users/REDACTED_USER/Documents/Projects/my-app/node_modules/@REDACTED_SCOPE/REDACTED_REPO/src/components/Button/Button.tsx'
```